### PR TITLE
feat: add missing robot and sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,5 @@ Features:
 - ES6, React Hooks
 - Active classes for navigation, and for project filter on select
 - Filter projects by skill selection
-- 404 page if you try to go to a non-existing page
-- Transitions: Fade in project cards in /project page, when going to another page, SVG tracing on /project and /404
 
 **Last content update**: October 2024.

--- a/pages/index.js
+++ b/pages/index.js
@@ -130,7 +130,7 @@ const Home = () => {
             animate={{ y: 0 }}
           >
             <h1>
-              Irene Truong is a software engineer specializing in{' '}
+              {fullName} is a software engineer specializing in{' '}
               <span>Full-Stack Development</span>. She brings{' '}
               <span>experience</span> in both start-up and corporate settings.
             </h1>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,8 @@
+User-Agent: *
+Allow: /
+Disallow: /private/
+
+User-Agent: GPTBot
+Disallow: /
+
+Sitemap: https://irene-truong.netlify.app/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,26 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://irene-truong.netlify.app</loc>
+    <lastmod>2024-10-14T15:02:24.021Z</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>1</priority>
+  </url>
+  <url>
+    <loc>https://irene-truong.netlify.app/projects</loc>
+    <lastmod>2023-12-01T00:00:00.000Z</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://irene-truong.netlify.app/contact</loc>
+    <lastmod>2021-01-01T00:00:00.000Z</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://irene-truong.netlify.app/404</loc>
+    <lastmod>2021-01-01T00:00:00.000Z</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Next.js has evolved since I created this site in 2020. Since then, I prioritized package updates for security, but there have been updates such as supporting SEO better through the introduction of `robot.txt` and `sitemap.xml` files.

Lighthouse performance for this site used to be 100% but now stands at 92% for SEO. 

This PR aims to get the percentage back up. 

See:
https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots
https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap